### PR TITLE
Update api/openapi/swagger.yaml, api/swagger_server/swagger/swagger.y…

### DIFF
--- a/api/openapi/swagger.yaml
+++ b/api/openapi/swagger.yaml
@@ -344,6 +344,8 @@ components:
           type: string
         uri:
           type: string
+        idofuri_default:
+          type: string
         broader_term:
           type: string
         synonym:
@@ -380,6 +382,7 @@ components:
         preferred_label: os
         language: ja
         uri: http://test/0/os
+        idofuri_default: os
         broader_term: http://myVocab/3
         synonym: オペレーティングシステム
         other_voc_syn_uri: http://otherVocab/16
@@ -487,6 +490,7 @@ components:
           preferred_label: os
           language: ja
           uri: http://test/0/os
+          idofuri_default: os
           broader_term: http://myVocab/3
           synonym: オペレーティングシステム
           other_voc_syn_uri: http://otherVocab/16

--- a/api/swagger_server/controllers/file_controller.py
+++ b/api/swagger_server/controllers/file_controller.py
@@ -389,6 +389,9 @@ def _make_bulk_data_editing_vocabulary(data_frame):
         if '代表語のURI' in item:
             insert_data['uri'] =\
                 item['代表語のURI'] if pd.notnull(item['代表語のURI']) else None
+            insert_data['idofuri_default'] =\
+                item['代表語のURI'].rsplit('/', 1)[1] if len(item['代表語のURI'].rsplit('/', 1)) > 1 else None
+            print('uri[', insert_data['uri'],']---idofuri[',insert_data['idofuri_default'],']')
         if '上位語のURI' in item:
             insert_data['broader_term'] =\
                 item['上位語のURI'] if pd.notnull(item['上位語のURI']) else None

--- a/api/swagger_server/models/editing_vocabulary.py
+++ b/api/swagger_server/models/editing_vocabulary.py
@@ -17,7 +17,7 @@ class EditingVocabulary(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, id: int=None, term: str=None, preferred_label: str=None, language: str=None, uri: str=None, broader_term: str=None, synonym: List[str]=None, other_voc_syn_uri: str=None, term_description: str=None, created_time: str=None, modified_time: str=None, synonym_candidate: List[str]=None, broader_term_candidate: List[str]=None, postion_x: str=None, postion_y: str=None, color1: str=None, color2: str=None):  # noqa: E501
+    def __init__(self, id: int=None, term: str=None, preferred_label: str=None, language: str=None, uri: str=None, idofuri_default: str=None, broader_term: str=None, synonym: List[str]=None, other_voc_syn_uri: str=None, term_description: str=None, created_time: str=None, modified_time: str=None, synonym_candidate: List[str]=None, broader_term_candidate: List[str]=None, postion_x: str=None, postion_y: str=None, color1: str=None, color2: str=None):  # noqa: E501
         """EditingVocabulary - a model defined in Swagger
 
         :param id: The id of this EditingVocabulary.  # noqa: E501
@@ -30,6 +30,8 @@ class EditingVocabulary(Model):
         :type language: str
         :param uri: The uri of this EditingVocabulary.  # noqa: E501
         :type uri: str
+        :param idofuri_default: The idofuri_default of this EditingVocabulary.  # noqa: E501
+        :type idofuri_default: str
         :param broader_term: The broader_term of this EditingVocabulary.  # noqa: E501
         :type broader_term: str
         :param synonym: The synonym of this EditingVocabulary.  # noqa: E501
@@ -61,6 +63,7 @@ class EditingVocabulary(Model):
             'preferred_label': str,
             'language': str,
             'uri': str,
+            'idofuri_default': str,
             'broader_term': str,
             'synonym': List[str],
             'other_voc_syn_uri': str,
@@ -81,6 +84,7 @@ class EditingVocabulary(Model):
             'preferred_label': 'preferred_label',
             'language': 'language',
             'uri': 'uri',
+            'idofuri_default': 'idofuri_default',
             'broader_term': 'broader_term',
             'synonym': 'synonym',
             'other_voc_syn_uri': 'other_voc_syn_uri',
@@ -99,6 +103,7 @@ class EditingVocabulary(Model):
         self._preferred_label = preferred_label
         self._language = language
         self._uri = uri
+        self._idofuri_default = idofuri_default
         self._broader_term = broader_term
         self._synonym = synonym
         self._other_voc_syn_uri = other_voc_syn_uri
@@ -227,6 +232,27 @@ class EditingVocabulary(Model):
         """
 
         self._uri = uri
+
+    @property
+    def idofuri_default(self) -> str:
+        """Gets the idofuri_default of this EditingVocabulary.
+
+
+        :return: The idofuri_default of this EditingVocabulary.
+        :rtype: str
+        """
+        return self._idofuri_default
+
+    @uri.setter
+    def idofuri_default(self, idofuri_default: str):
+        """Sets the idofuri_default of this EditingVocabulary.
+
+
+        :param idofuri_default: The idofuri_default of this EditingVocabulary.
+        :type idofuri_default: str
+        """
+
+        self._idofuri_default = idofuri_default
 
     @property
     def broader_term(self) -> str:

--- a/api/swagger_server/swagger/swagger.yaml
+++ b/api/swagger_server/swagger/swagger.yaml
@@ -344,6 +344,8 @@ components:
           type: string
         uri:
           type: string
+        idofuri_default:
+          type: string
         broader_term:
           type: string
         synonym:
@@ -380,6 +382,7 @@ components:
         preferred_label: os
         language: ja
         uri: http://test/0/os
+        idofuri_default: os
         broader_term: http://myVocab/3
         synonym: オペレーティングシステム
         other_voc_syn_uri: http://otherVocab/16
@@ -487,6 +490,7 @@ components:
           preferred_label: os
           language: ja
           uri: http://test/0/os
+          idofuri_default: os
           broader_term: http://myVocab/3
           synonym: オペレーティングシステム
           other_voc_syn_uri: http://otherVocab/16

--- a/app/app/client/components/DialogSettingSynonym.js
+++ b/app/app/client/components/DialogSettingSynonym.js
@@ -124,7 +124,7 @@ export default class DialogSettingSynonym extends React.Component {
         this.broaderList[ currentNode.language].push( targetNode.broader_term)
       }
     })
-    if(  this.broaderList['ja'].length + this.broaderList['en'].length > 0 ){
+    if(  this.broaderList['ja'].length + this.broaderList['en'].length > 1 ){
       this.broaderClassName= this.props.classes.formControl;
     }
   }

--- a/db/init/1_createdb.sql
+++ b/db/init/1_createdb.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS editing_vocabulary (
   "preferred_label" text,
   "language" text,
   "uri" text,
+  "idofuri_default" text,
   "broader_term" text,
   "other_voc_syn_uri" text,
   "term_description" text,


### PR DESCRIPTION
…aml, file_controller.py, editing_vocabulary.py, EditingVocabulary.js, DialogSettingSynonym.js, 1_createdb.sql - URI always uses PreferredLabels id and Not yet supported when PreferredLabel is missing