### PR TITLE
Revert "Update api/openapi/swagger.yaml, api/swagger_server/swagger/s…

### DIFF
--- a/api/openapi/swagger.yaml
+++ b/api/openapi/swagger.yaml
@@ -344,8 +344,6 @@ components:
           type: string
         uri:
           type: string
-        idofuri_default:
-          type: string
         broader_term:
           type: string
         synonym:
@@ -382,7 +380,6 @@ components:
         preferred_label: os
         language: ja
         uri: http://test/0/os
-        idofuri_default: os
         broader_term: http://myVocab/3
         synonym: オペレーティングシステム
         other_voc_syn_uri: http://otherVocab/16
@@ -490,7 +487,6 @@ components:
           preferred_label: os
           language: ja
           uri: http://test/0/os
-          idofuri_default: os
           broader_term: http://myVocab/3
           synonym: オペレーティングシステム
           other_voc_syn_uri: http://otherVocab/16

--- a/api/swagger_server/controllers/file_controller.py
+++ b/api/swagger_server/controllers/file_controller.py
@@ -389,9 +389,6 @@ def _make_bulk_data_editing_vocabulary(data_frame):
         if '代表語のURI' in item:
             insert_data['uri'] =\
                 item['代表語のURI'] if pd.notnull(item['代表語のURI']) else None
-            insert_data['idofuri_default'] =\
-                item['代表語のURI'].rsplit('/', 1)[1] if len(item['代表語のURI'].rsplit('/', 1)) > 1 else None
-            print('uri[', insert_data['uri'],']---idofuri[',insert_data['idofuri_default'],']')
         if '上位語のURI' in item:
             insert_data['broader_term'] =\
                 item['上位語のURI'] if pd.notnull(item['上位語のURI']) else None

--- a/api/swagger_server/models/editing_vocabulary.py
+++ b/api/swagger_server/models/editing_vocabulary.py
@@ -17,7 +17,7 @@ class EditingVocabulary(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, id: int=None, term: str=None, preferred_label: str=None, language: str=None, uri: str=None, idofuri_default: str=None, broader_term: str=None, synonym: List[str]=None, other_voc_syn_uri: str=None, term_description: str=None, created_time: str=None, modified_time: str=None, synonym_candidate: List[str]=None, broader_term_candidate: List[str]=None, postion_x: str=None, postion_y: str=None, color1: str=None, color2: str=None):  # noqa: E501
+    def __init__(self, id: int=None, term: str=None, preferred_label: str=None, language: str=None, uri: str=None, broader_term: str=None, synonym: List[str]=None, other_voc_syn_uri: str=None, term_description: str=None, created_time: str=None, modified_time: str=None, synonym_candidate: List[str]=None, broader_term_candidate: List[str]=None, postion_x: str=None, postion_y: str=None, color1: str=None, color2: str=None):  # noqa: E501
         """EditingVocabulary - a model defined in Swagger
 
         :param id: The id of this EditingVocabulary.  # noqa: E501
@@ -30,8 +30,6 @@ class EditingVocabulary(Model):
         :type language: str
         :param uri: The uri of this EditingVocabulary.  # noqa: E501
         :type uri: str
-        :param idofuri_default: The idofuri_default of this EditingVocabulary.  # noqa: E501
-        :type idofuri_default: str
         :param broader_term: The broader_term of this EditingVocabulary.  # noqa: E501
         :type broader_term: str
         :param synonym: The synonym of this EditingVocabulary.  # noqa: E501
@@ -63,7 +61,6 @@ class EditingVocabulary(Model):
             'preferred_label': str,
             'language': str,
             'uri': str,
-            'idofuri_default': str,
             'broader_term': str,
             'synonym': List[str],
             'other_voc_syn_uri': str,
@@ -84,7 +81,6 @@ class EditingVocabulary(Model):
             'preferred_label': 'preferred_label',
             'language': 'language',
             'uri': 'uri',
-            'idofuri_default': 'idofuri_default',
             'broader_term': 'broader_term',
             'synonym': 'synonym',
             'other_voc_syn_uri': 'other_voc_syn_uri',
@@ -103,7 +99,6 @@ class EditingVocabulary(Model):
         self._preferred_label = preferred_label
         self._language = language
         self._uri = uri
-        self._idofuri_default = idofuri_default
         self._broader_term = broader_term
         self._synonym = synonym
         self._other_voc_syn_uri = other_voc_syn_uri
@@ -232,27 +227,6 @@ class EditingVocabulary(Model):
         """
 
         self._uri = uri
-
-    @property
-    def idofuri_default(self) -> str:
-        """Gets the idofuri_default of this EditingVocabulary.
-
-
-        :return: The idofuri_default of this EditingVocabulary.
-        :rtype: str
-        """
-        return self._idofuri_default
-
-    @uri.setter
-    def idofuri_default(self, idofuri_default: str):
-        """Sets the idofuri_default of this EditingVocabulary.
-
-
-        :param idofuri_default: The idofuri_default of this EditingVocabulary.
-        :type idofuri_default: str
-        """
-
-        self._idofuri_default = idofuri_default
 
     @property
     def broader_term(self) -> str:

--- a/api/swagger_server/swagger/swagger.yaml
+++ b/api/swagger_server/swagger/swagger.yaml
@@ -344,8 +344,6 @@ components:
           type: string
         uri:
           type: string
-        idofuri_default:
-          type: string
         broader_term:
           type: string
         synonym:
@@ -382,7 +380,6 @@ components:
         preferred_label: os
         language: ja
         uri: http://test/0/os
-        idofuri_default: os
         broader_term: http://myVocab/3
         synonym: オペレーティングシステム
         other_voc_syn_uri: http://otherVocab/16
@@ -490,7 +487,6 @@ components:
           preferred_label: os
           language: ja
           uri: http://test/0/os
-          idofuri_default: os
           broader_term: http://myVocab/3
           synonym: オペレーティングシステム
           other_voc_syn_uri: http://otherVocab/16

--- a/app/app/client/components/DialogSettingSynonym.js
+++ b/app/app/client/components/DialogSettingSynonym.js
@@ -124,7 +124,7 @@ export default class DialogSettingSynonym extends React.Component {
         this.broaderList[ currentNode.language].push( targetNode.broader_term)
       }
     })
-    if(  this.broaderList['ja'].length + this.broaderList['en'].length > 1 ){
+    if(  this.broaderList['ja'].length + this.broaderList['en'].length > 0 ){
       this.broaderClassName= this.props.classes.formControl;
     }
   }

--- a/app/app/client/stores/EditingVocabulary.js
+++ b/app/app/client/stores/EditingVocabulary.js
@@ -288,16 +288,13 @@ class EditingVocabulary {
         }
       } 
       
+      data.idofuri = data.uri.substring(data.uri.lastIndexOf('/')+1);
+
       // If the parameter is string (Set the empty string character)
       if (!data.preferred_label) data.preferred_label = '';
       if (!data.language) data.language = '';
-      if (!data.uri){
-        data.uri = '';
-        data.idofuri = '';
-      } else{
-        data.idofuri = data.uri.substring(data.uri.lastIndexOf('/')+1);
-      }
-      if (!data.idofuri_default) data.idofuri_default = '';
+      if (!data.uri) data.idofuri = '';
+      if (!data.uri) data.uri = '';
       if (!data.broader_term) data.broader_term = '';
       if (!data.other_voc_syn_uri) data.other_voc_syn_uri = '';
       if (!data.term_description) data.term_description = '';
@@ -1773,7 +1770,7 @@ isOtherVocSynUriChanged() {
    */
    @action isBlankTerm( term){
     const blankPrefix = this.getTermBlankPrefix();
-    if(term && term.indexOf( blankPrefix) != -1){
+    if(term.indexOf( blankPrefix) != -1){
       return true;
     }
     return false;
@@ -1896,14 +1893,14 @@ isOtherVocSynUriChanged() {
       if (currentNode.id) {
         // If the selected term is not in the editing vocabulary data, register it as a new term.
         // This is the case when the term is not selected and the term is entered in the title field
-        previous.push(this.makeVocabularyHistoryData(currentNode));
+        previous.push(this.makeVocabularyHistoryData(currentNode));//OK
       }
 
       if( !updateCurrent){
         // Add selected vocabulary
-        updateCurrent = this.createDBFormatDataByCurrentNode(currentNode);
+        updateCurrent = this.createDBFormatDataByCurrentNode(currentNode);//ok
 
-        following.push(this.makeVocabularyHistoryData(updateCurrent));
+        following.push(this.makeVocabularyHistoryData(updateCurrent));//ok
         updateTermList.push(updateCurrent);
 
       }
@@ -2373,7 +2370,7 @@ isOtherVocSynUriChanged() {
           previous.push(this.makeVocabularyHistoryData(objDelSynonym));
           // Removed synonyms were words belonging to the editing vocabulary (preferred label), so remove the association with the editing vocabulary
           objDelSynonym.preferred_label = setPreferred_label;
-          objDelSynonym.uri = objDelSynonym.uri.replace(objDelSynonym.uri.substring(objDelSynonym.uri.lastIndexOf('/')+1), objDelSynonym.idofuri_default);
+          objDelSynonym.uri = '';
           console.log(
               '[updateVocabulary] ' +
               synonym +
@@ -2928,13 +2925,13 @@ isOtherVocSynUriChanged() {
         return item.idofuri == find.idofuri && item.language != find.language
       })
       langDiffFilters.forEach((node)=>{
-        if(node.broader_term != '') newLangDiffValue.push(node.broader_term);
+        if(node.preferred_label != '') newLangDiffValue.push(node.preferred_label);
       });
     });
 
     const broaderTermNewList={ja:[], en:[]};
     broaderTermNewList[this.tmpLanguage.list] = newValue;
-    broaderTermNewList[this.tmpLanguage.list=='ja'?'en':'ja'] = newLangDiffValue.length>0?newLangDiffValue:this.tmpBroaderTerm.list[this.tmpLanguage.list=='ja'?'en':'ja'];
+    broaderTermNewList[this.tmpLanguage.list=='ja'?'en':'ja'] = newLangDiffValue;
 
     [ this.currentNode, this.currentLangDiffNode].forEach((currentNode)=>{
 
@@ -3095,7 +3092,7 @@ isOtherVocSynUriChanged() {
    */
   @action updataSynonym(newValue) {
 
-    const newLangDiffValue = this.tmpSynonym.list[this.tmpLanguage.list=='ja'?'en':'ja'];
+    const newLangDiffValue = [];
     newValue.forEach((term)=>{
       const find = this.editingVocabulary.find((d)=>d.term==term)
       const langDiffFilters=this.editingVocabulary.filter((item)=>{
@@ -3120,9 +3117,20 @@ isOtherVocSynUriChanged() {
           }else if ( synonym !== currentNode.term) {
             array.push(synonym);
           }
-        } else { // should be currentLangDiffNode
-          // If there are two or more preferred labels, they cannot be registered and it is difficult to complete them properly, so they are displayed as they are
-          array.push(synonym);
+        } else {
+          if (this.tmpPreferredLabel.list[currentNode.language].length == 0) {
+            // Do not allow addition to a synonym if preferred label does not exist
+          } else if (this.tmpPreferredLabel.list[currentNode.language].length == 1) {
+            // Do not add to synonyms when they are added with no vocabulary selected
+            const find = this.tmpPreferredLabel.list[currentNode.language].find(
+                (prfrrdlbl) => prfrrdlbl == synonym);
+            if (!find) {
+              array.push(synonym);
+            }
+          } else {
+            // If there are two or more preferred labels, they cannot be registered and it is difficult to complete them properly, so they are displayed as they are
+            array.push(synonym);
+          }
         }
       });
       // Complete only for additional updates
@@ -3251,33 +3259,18 @@ isOtherVocSynUriChanged() {
       array.push(term);
     });
 
-    let arrayLangDiff = [];
+    const arrayLangDiff = [];
     newValue.forEach((term)=>{
       const find = this.editingVocabulary.find((d)=>d.term==term)
       const langDiffnode=this.editingVocabulary.find((item)=>{
         return item.idofuri == find.idofuri && item.language != find.language
       })
-      if(langDiffnode && langDiffnode.preferred_label != '') arrayLangDiff.push(langDiffnode.preferred_label);
+      if(langDiffnode.preferred_label != '') arrayLangDiff.push(langDiffnode.preferred_label);
     });
-
-    arrayLangDiff = arrayLangDiff.filter((val, i, self)=>{ return i === self.indexOf(val)});
-    arrayLangDiff = arrayLangDiff.length>0?arrayLangDiff:this.tmpPreferredLabel.list[this.tmpLanguage.list=='ja'?'en':'ja'];
 
     this.tmpPreferredLabel.id = this.currentNode.id;  // Setting 'this.currentNode' on purpose
     this.tmpPreferredLabel.list[this.tmpLanguage.list] = array.filter((val, i, self)=>{ return i === self.indexOf(val)});
-    this.tmpPreferredLabel.list[this.tmpLanguage.list=='ja'?'en':'ja'] = arrayLangDiff;
-
-    let targetPreferredLabel=false
-    if( this.tmpPreferredLabel.list['ja'].length == 1){ // Japanese PreferredLabel takes precedence
-      targetPreferredLabel = this.tmpPreferredLabel.list['ja'][0];
-    }else if(this.tmpPreferredLabel.list['ja'].length == 0 && this.tmpPreferredLabel.list['en'].length == 1){
-      targetPreferredLabel = this.tmpPreferredLabel.list['en'][0];
-    }
-    if( targetPreferredLabel){
-      const preferredNode = this.editingVocabulary.find((data) => data.term === targetPreferredLabel );
-      if(preferredNode)
-        this.tmpIdofUri.list = [ preferredNode.idofuri_default ];
-    }
+    this.tmpPreferredLabel.list[this.tmpLanguage.list=='ja'?'en':'ja'] = arrayLangDiff.filter((val, i, self)=>{ return i === self.indexOf(val)});
   }
 
   /**

--- a/db/init/1_createdb.sql
+++ b/db/init/1_createdb.sql
@@ -5,7 +5,6 @@ CREATE TABLE IF NOT EXISTS editing_vocabulary (
   "preferred_label" text,
   "language" text,
   "uri" text,
-  "idofuri_default" text,
   "broader_term" text,
   "other_voc_syn_uri" text,
   "term_description" text,


### PR DESCRIPTION
…wagger.yaml, file_controller.py, editing_vocabulary.py, EditingVocabulary.js, DialogSettingSynonym.js, 1_createdb.sql - URI always uses PreferredLabels id and Not yet supported when PreferredLabel is missing"

This reverts commit ac918ea037931456353c7b78986c952ceabcbefe.